### PR TITLE
fix: regex for display name validation to prevent leading spaces

### DIFF
--- a/packages/utils/schemas.ts
+++ b/packages/utils/schemas.ts
@@ -16,9 +16,9 @@ export const usernameSchema = z
 
 export const displayNameSchema = z
   .string()
-  .regex(/^[^ ]+$/, "Display name must not start with a space.")
+  .regex(/^[^\s].*$/, "Display name must not start with a space.")
   .max(24, "Display name must be less than 24 characters.")
-  .min(2, "Display name must at least 2 characters.");
+  .min(2, "Display name must be at least 2 characters.");
 
 export const occupationSchema = z
   .string()


### PR DESCRIPTION
Updated regex from `/^[^ ]+$/` → `/^[^\s].*$/` to allow spaces inside but not at the start of the display name.